### PR TITLE
style: images of people loading without traced_SVG

### DIFF
--- a/src/components/ThePeople.tsx
+++ b/src/components/ThePeople.tsx
@@ -14,42 +14,42 @@ const ThePeople = () => {
 			jassyr: file(relativePath: { eq: "jassyr.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}
 			joakim: file(relativePath: { eq: "joakim.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}
 			johan: file(relativePath: { eq: "johan.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}
 			niclas: file(relativePath: { eq: "niclas.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}
 			daniel: file(relativePath: { eq: "daniel.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}
 			philip: file(relativePath: { eq: "philip.jpg" }) {
 				childImageSharp {
 					fluid(maxWidth: 500) {
-						...GatsbyImageSharpFluid_tracedSVG
+						...GatsbyImageSharpFluid
 					}
 				}
 			}


### PR DESCRIPTION
To make it avoid it looking less weird. This doens't resolve slow
loading times but shows a blur of the expected image rather than
a vectorized trace.