### PR TITLE
Move 'Våra Kunder' and fix background colors

### DIFF
--- a/src/components/Career/Apply.tsx
+++ b/src/components/Career/Apply.tsx
@@ -9,34 +9,34 @@ type Variant = {
 	text: String;
 	emailText: String;
 	email: String;
-}
-const variants: {[key: string]: Variant} = {
+};
+const variants: { [key: string]: Variant } = {
 	default: {
-		caption: "Bli en i gänget",
-		header: "Ansök här",
-		text: "Vill du jobba hos oss?",
-		emailText: "Skicka ett mail till oss på",
-		email: "kontakt@etimo.se",
+		caption: 'Bli en i gänget',
+		header: 'Ansök här',
+		text: 'Vill du jobba hos oss?',
+		emailText: 'Skicka ett mail till oss på',
+		email: 'kontakt@etimo.se',
 	},
 	customers: {
-		caption: "Bättre mjukvara för en bättre värld",
-		header: "Kontakta oss",
-		text: "Behöver du teknikkompetens i världsklass?",
-		emailText: "Skicka ett mail till Johan på",
-		email: "johan.hazelius@etimo.se",
+		caption: 'Bättre mjukvara för en bättre värld',
+		header: 'Kontakta oss',
+		text: 'Behöver du teknikkompetens i världsklass?',
+		emailText: 'Skicka ett mail till Johan på',
+		email: 'johan.hazelius@etimo.se',
 	},
-}
+};
 
 type Props = {
 	variantKey: string;
-}
-
+	backgroundColor?: string;
+};
 
 const Apply = (props: Props) => {
-	const { variantKey } = props;
+	const { variantKey, backgroundColor } = props;
 	const variant = variants[variantKey];
 	return (
-		<Section style={{ backgroundColor: 'white' }}>
+		<Section style={{ backgroundColor }}>
 			<div className="flex container flex-col px-8 lg:px-32 text-center overflow-hidden">
 				<FloatUp>
 					<Caption>{variant.caption}</Caption>

--- a/src/components/Clients/ClientCustomers.tsx
+++ b/src/components/Clients/ClientCustomers.tsx
@@ -298,7 +298,11 @@ const ClientCustomers = () => {
 
 	return (
 		<>
-			<Customers imgDiv={ImageDiv} givenCustomers={customers} />
+			<Customers
+				imgDiv={ImageDiv}
+				givenCustomers={customers}
+				backgroundColor="white"
+			/>
 		</>
 	);
 };

--- a/src/components/Clients/Competences.tsx
+++ b/src/components/Clients/Competences.tsx
@@ -5,7 +5,7 @@ import Section from '../Section';
 
 const Competences = () => {
 	return (
-		<Section>
+		<Section style={{ background: 'white' }}>
 			<div className="flex container flex-col px-8 xl:px-32 text-center overflow-hidden">
 				<FloatUp>
 					<Caption>Områden</Caption>

--- a/src/components/Clients/CreateValue.tsx
+++ b/src/components/Clients/CreateValue.tsx
@@ -7,7 +7,7 @@ import Section from '../Section';
 
 const CreateValue = () => {
 	return (
-		<Section style={{ background: 'white' }}>
+		<Section>
 			<div className="flex container flex-col px-8 xl:px-32 text-center overflow-hidden">
 				<FloatUp>
 					<Caption>Våra tjänster</Caption>

--- a/src/components/Clients/ReferenceCase.tsx
+++ b/src/components/Clients/ReferenceCase.tsx
@@ -10,7 +10,7 @@ import EmphasizedH2 from '../../elements/EmphasizedH2';
 const ReferenceCase = () => {
 	const [h, width] = useViewportSize();
 	return (
-		<Section>
+		<Section style={{ background: 'white' }}>
 			<div className="flex container flex-col md:flex-row px-8 lg:px-32">
 				<div className="md:w-1/2">
 					<FadeIn direction="left" flex flexDirection="column">

--- a/src/components/Clients/Services.tsx
+++ b/src/components/Clients/Services.tsx
@@ -32,7 +32,7 @@ const Services = () => {
 	const [ref, inView] = useInView();
 
 	return (
-		<Section style={{ backgroundColor: 'white' }}>
+		<Section>
 			<div className="flex container flex-col px-8 xl:px-32 text-center overflow-hidden">
 				<FloatUp>
 					<Caption>Nöjda kunder</Caption>

--- a/src/components/Customers.tsx
+++ b/src/components/Customers.tsx
@@ -166,9 +166,16 @@ type CustomersProps = {
 	}[];
 	link?: boolean;
 	imgDiv?: StyledComponent<'div', DefaultTheme, {}, never>;
+	backgroundColor?: string;
 };
 
-export default ({ givenCustomers, link, imgDiv, ...props }: CustomersProps) => {
+export default ({
+	givenCustomers,
+	link,
+	imgDiv,
+	backgroundColor,
+	...props
+}: CustomersProps) => {
 	const customers = givenCustomers ? givenCustomers : generateCustomers();
 
 	/* max-width: 150px; */
@@ -180,7 +187,7 @@ export default ({ givenCustomers, link, imgDiv, ...props }: CustomersProps) => {
 		  `;
 
 	return (
-		<Section style={{ overflow: 'hidden' }}>
+		<Section style={{ overflow: 'hidden', backgroundColor }}>
 			<div className="container mx-auto xl:px-12">
 				<div className="flex flex-col mb-8">
 					<FloatUp>

--- a/src/pages/karriar.tsx
+++ b/src/pages/karriar.tsx
@@ -36,7 +36,7 @@ const CareerPage = () => {
 			<IntroText />
 			<WorkingHere />
 			<WhoAreYou />
-			<Apply variantKey="default" />
+			<Apply variantKey="default" backgroundColor="white" />
 		</Layout>
 	);
 };

--- a/src/pages/kunder-och-expertis.tsx
+++ b/src/pages/kunder-och-expertis.tsx
@@ -25,26 +25,26 @@ const ClientsPage = () => {
 		},
 		{
 			index: 1,
-			name: 'Värde för kund',
-		},
-		{
-			index: 2,
-			name: 'Kompetenser',
-		},
-		{
-			index: 3,
-			name: 'Tjänster',
-		},
-		{
-			index: 4,
-			name: 'Referenscase',
-		},
-		{
-			index: 5,
 			name: 'Våra kunder',
 		},
 		{
+			index: 2,
+			name: 'Värde för kund',
+		},
+		{
+			index: 3,
+			name: 'Kompetenser',
+		},
+		{
+			index: 4,
+			name: 'Tjänster',
+		},
+		{
 			index: 5,
+			name: 'Referenscase',
+		},
+		{
+			index: 6,
 			name: 'Kontakt',
 		},
 	];
@@ -54,11 +54,11 @@ const ClientsPage = () => {
 			<SEO title="Kunder och expertis" />
 			{scrollbarEnabled && <Scroller givenSections={sections} />}
 			<Hero />
+			<ClientCustomers />
 			<CreateValue />
 			<Competences />
 			<Services />
 			<ReferenceCase />
-			<ClientCustomers />
 			<Apply variantKey="customers" />
 		</Layout>
 	);


### PR DESCRIPTION
Moved 'Våra kunder' to top on 'Kunder' page.
Fixed so we display sections in correct colors. (grey/white).

Closes #108