### PR TITLE
fix: problem with hidden text on small or zoomed in screens

### DIFF
--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled, { DefaultTheme, ThemeProps } from 'styled-components';
 import tw from 'twin.macro';
-import { sizes } from '../helpers';
-import { useViewportSize } from '../hooks';
+import { useSectionHeight } from '../hooks';
 
 type StyleProps = {
 	height?: number;
@@ -27,23 +26,10 @@ type Props = {
 };
 
 export default ({ children, headerSpace, ...props }: Props) => {
-	const [height, width] = useViewportSize();
-
-	const isMobile = () => width < sizes().laptop;
-	const getHeight = () => {
-		// Don't set a height if it's a mobile phone
-		// since we don't use a left menu on mobile.
-		if (isMobile()) {
-			return undefined;
-		}
-		if (height < sizes().minimumHeight) {
-			return sizes().minimumHeight - (headerSpace ? sizes().headerHeight : 0);
-		}
-		return headerSpace ? height - sizes().headerHeight : height;
-	};
+	const sectionHeight = useSectionHeight(headerSpace);
 
 	return (
-		<Section height={getHeight()} {...props}>
+		<Section height={sectionHeight} {...props}>
 			{children}
 		</Section>
 	);

--- a/src/components/WorkAtEtimo.tsx
+++ b/src/components/WorkAtEtimo.tsx
@@ -9,14 +9,19 @@ import Caption from '../elements/Caption';
 import H2 from '../elements/H2';
 import Span from '../elements/Span';
 import { sizes } from '../helpers';
-import { useViewportSize } from '../hooks';
+import { useSectionHeight, useViewportSize } from '../hooks';
 import { HighlightButton } from './Button';
 import Section from './Section';
 import DashedP from './DashedP';
 
-const CustomBackground = styled.div<{ offset: number }>`
+type CustomBackgroundProps = {
+	offset: number;
+	height: number;
+};
+
+const CustomBackground = styled.div<CustomBackgroundProps>`
 	position: absolute;
-	height: 125%;
+	height: ${(props) => props.height + 'px'};
 	left: calc(50% + 275px);
 	top: ${(props) => props.offset + 'px'};
 	right: 0;
@@ -60,11 +65,14 @@ const WorkAtEtimo = () => {
 		}
 	`);
 
+	const sectionHeight = useSectionHeight();
 	const [height, width] = useViewportSize();
 
 	return (
 		<Section>
-			{width >= sizes().laptop && <CustomBackground offset={height * 2} />}
+			{width >= sizes().laptop && sectionHeight && (
+				<CustomBackground offset={sectionHeight * 2} height={sectionHeight} />
+			)}
 			<div className="container xl:px-24 lg:max-h-95">
 				<div className="flex flex-col xl:pl-12 lg:flex-row items-center lg:justify-center">
 					<div className="w-4/5 sm:w-3/4 lg:w-3/5 lg:mr-2 xl:mr-4 mb-2 lg:mb-0">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useViewportSize } from './useViewportSize';
 export { default as useInterval } from './useInterval';
+export { default as useSectionHeight } from './useSectionHeight';

--- a/src/hooks/useSectionHeight.ts
+++ b/src/hooks/useSectionHeight.ts
@@ -1,0 +1,28 @@
+import useViewportSize from './useViewportSize';
+import { sizes } from '../helpers';
+import { useMemo } from 'react';
+
+function useSectionHeight(hasHeaderSpace?: boolean) {
+	const isMobile = () => width < sizes().laptop;
+	const [height, width] = useViewportSize();
+
+	const getHeight = () => {
+		// Don't set a height if it's a mobile phone
+		// since we don't use a left menu on mobile.
+		if (isMobile()) {
+			return undefined;
+		}
+		if (height < sizes().minimumHeight) {
+			return (
+				sizes().minimumHeight - (hasHeaderSpace ? sizes().headerHeight : 0)
+			);
+		}
+		return hasHeaderSpace ? height - sizes().headerHeight : height;
+	};
+
+	const sectionHeight = useMemo(() => getHeight(), [height, hasHeaderSpace]);
+
+	return sectionHeight;
+}
+
+export default useSectionHeight;


### PR DESCRIPTION
The "CustomBackground" used a different section height than "section" which did not have a minimum height. I made a hook for calculating the section height which is now used both by "section" and "CustomBackground" so that the custom background has the same height as the section on all screen sizes. 