### PR TITLE
fix: background color and header space on career and services pages

### DIFF
--- a/src/components/Career/WhoAreYou.tsx
+++ b/src/components/Career/WhoAreYou.tsx
@@ -19,7 +19,7 @@ const whoTexts = [
 
 const WhoAreYou = () => {
 	return (
-		<Section>
+		<Section style={{ backgroundColor: 'white' }}>
 			<div className="flex container flex-col px-8 lg:px-32 text-center">
 				<FloatUp>
 					<Caption>Vi söker de allra bästa</Caption>

--- a/src/components/Career/WorkingHere.tsx
+++ b/src/components/Career/WorkingHere.tsx
@@ -18,7 +18,7 @@ const bulletPoints = [
 
 const WorkingHere = () => {
 	return (
-		<Section style={{ backgroundColor: 'white' }}>
+		<Section headerSpace>
 			<div className="flex container flex-col md:flex-row px-8 lg:px-32 text-left">
 				<div className="flex flex-col lg:w-1/2 my-auto md:mt-60p lg:mt-0 text-center md:text-left overflow-hidden">
 					<FloatUp>

--- a/src/components/Clients/OurServices.tsx
+++ b/src/components/Clients/OurServices.tsx
@@ -52,7 +52,7 @@ export const OurServices = () => {
 	const [ref, inView] = useInView({ triggerOnce: true });
 
 	return (
-		<Section>
+		<Section headerSpace>
 			<div className="container mx-auto xl:px-32">
 				<div className="flex flex-col mb-8 overflow-hidden">
 					<FloatUp>

--- a/src/pages/karriar.tsx
+++ b/src/pages/karriar.tsx
@@ -30,7 +30,7 @@ const CareerPage = () => {
 			{scrollbarEnabled && <Scroller givenSections={sections} />}
 			<WorkingHere />
 			<WhoAreYou />
-			<Apply variantKey="default" backgroundColor="white" />
+			<Apply variantKey="default" />
 		</Layout>
 	);
 };


### PR DESCRIPTION
- Made background color gray for first career section to fit with current template
- Fixed scrolling to scroll to correct position, since the header size was not accounted for when the hero was removed, the scroll menu scrolls to almost the correct position on the services and career pages. 